### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -54,6 +54,9 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
+# Yarn lock file
+yarn.lock
+
 # dotenv environment variables file
 .env
 


### PR DESCRIPTION
Yarn lock is a generated file, I don't see any reason for it being tracked.
